### PR TITLE
feature(gen): add MonoImporter

### DIFF
--- a/tool/unity-meta-autofix/autofix/create.go
+++ b/tool/unity-meta-autofix/autofix/create.go
@@ -24,6 +24,8 @@ func NewMetaCreator(dryRun bool, guidGen meta.GUIDGen, logger logging.Logger) Me
 			metaGen = meta.DefaultImporterFolderGen{GUID: guid}
 		case MetaTypeTextScriptImporter:
 			metaGen = meta.TextScriptImporterGen{GUID: guid}
+		case MetaTypeMonoImporter:
+			metaGen = meta.MonoImporterGen{GUID: guid}
 		default:
 			return fmt.Errorf("unsupported meta type: %q", metaType)
 		}

--- a/tool/unity-meta-autofix/autofix/metatype.go
+++ b/tool/unity-meta-autofix/autofix/metatype.go
@@ -13,6 +13,7 @@ type MetaType string
 const (
 	MetaTypeDefaultImporterFolder MetaType = "MetaTypeDefaultImporterFolder"
 	MetaTypeTextScriptImporter    MetaType = "MetaTypeTextScriptImporter"
+	MetaTypeMonoImporter          MetaType = "MetaTypeMonoImporter"
 )
 
 type MetaTypeDetector func(missingMeta typedpath.RawPath) (MetaType, error)
@@ -36,6 +37,8 @@ func NewMetaTypeDetector(isDir ostestable.IsDir) MetaTypeDetector {
 		switch strings.ToLower(ext) {
 		case ".json", ".bytes", ".csv", ".pb", ".txt", ".xml", ".proto":
 			return MetaTypeTextScriptImporter, nil
+		case ".cs":
+			return MetaTypeMonoImporter, nil	
 		default:
 			return "", fmt.Errorf("should not create .meta because the extension is not supported now: %s", originalPath)
 		}

--- a/unity/meta/monoimportergen.go
+++ b/unity/meta/monoimportergen.go
@@ -16,7 +16,7 @@ func (t MonoImporterGen) WriteTo(writer io.Writer) (int64, error) {
 	content := strings.TrimLeft(fmt.Sprintf(`
 fileFormatVersion: 2
 guid: %s
-TextScriptImporter:
+MonoImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/unity/meta/monoimportergen.go
+++ b/unity/meta/monoimportergen.go
@@ -1,4 +1,3 @@
-
 package meta
 
 import (

--- a/unity/meta/monoimportergen.go
+++ b/unity/meta/monoimportergen.go
@@ -1,0 +1,32 @@
+
+package meta
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type MonoImporterGen struct {
+	GUID *GUID
+}
+
+var _ Gen = MonoImporterGen{}
+
+func (t MonoImporterGen) WriteTo(writer io.Writer) (int64, error) {
+	content := strings.TrimLeft(fmt.Sprintf(`
+fileFormatVersion: 2
+guid: %s
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+`, t.GUID.String()), "\n")
+	n, err := io.WriteString(writer, content)
+	return int64(n), err
+}

--- a/unity/meta/monoimportergen_test.go
+++ b/unity/meta/monoimportergen_test.go
@@ -1,0 +1,37 @@
+package meta_test
+
+import (
+	"bytes"
+	"github.com/DeNA/unity-meta-check/unity/meta"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestTextScriptImporterGen_WriteTo(t *testing.T) {
+	gen := meta.MonoImporterGen{GUID: meta.ZeroGUID()}
+
+	buf := &bytes.Buffer{}
+	_, err := gen.WriteTo(buf)
+	if err != nil {
+		t.Errorf("want nil, got %#v", err)
+		return
+	}
+
+	actual := buf.String()
+	expected := `fileFormatVersion: 2
+guid: 00000000000000000000000000000000
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+`
+	if actual != expected {
+		t.Error(cmp.Diff(expected, actual))
+		return
+	}
+}

--- a/unity/meta/monoimportergen_test.go
+++ b/unity/meta/monoimportergen_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestTextScriptImporterGen_WriteTo(t *testing.T) {
+func TestMonoImporterGen_WriteTo(t *testing.T) {
 	gen := meta.MonoImporterGen{GUID: meta.ZeroGUID()}
 
 	buf := &bytes.Buffer{}
@@ -20,7 +20,7 @@ func TestTextScriptImporterGen_WriteTo(t *testing.T) {
 	actual := buf.String()
 	expected := `fileFormatVersion: 2
 guid: 00000000000000000000000000000000
-TextScriptImporter:
+MonoImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
Add support for autofixing missing .cs.meta files, using the default unity content.

Also, as a side note, there is no image tagged with `latest` as stated in the Installation part of the readme:
```shell
$ docker pull ghcr.io/dena/unity-meta-check/unity-meta-check:latest
Error response from daemon: name unknown
```
This should be reported as an issue, but since you have that turned off...

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
