### PR TITLE
Autofix *.md and LICENSE

### DIFF
--- a/tool/unity-meta-autofix/autofix/metatype.go
+++ b/tool/unity-meta-autofix/autofix/metatype.go
@@ -35,12 +35,17 @@ func NewMetaTypeDetector(isDir ostestable.IsDir) MetaTypeDetector {
 		}
 
 		switch strings.ToLower(ext) {
-		case ".json", ".bytes", ".csv", ".pb", ".txt", ".xml", ".proto":
+		case ".json", ".bytes", ".csv", ".pb", ".txt", ".xml", ".proto", ".md":
 			return MetaTypeTextScriptImporter, nil
 		case ".cs":
-			return MetaTypeMonoImporter, nil	
+			return MetaTypeMonoImporter, nil
 		default:
-			return "", fmt.Errorf("should not create .meta because the extension is not supported now: %s", originalPath)
+			switch originalPath.Base() {
+			case "LICENSE":
+				return MetaTypeTextScriptImporter, nil
+			default:
+				return "", fmt.Errorf("should not create .meta because the extension is not supported now: %s", originalPath)
+			}
 		}
 	}
 }

--- a/tool/unity-meta-autofix/autofix/metatype_test.go
+++ b/tool/unity-meta-autofix/autofix/metatype_test.go
@@ -28,6 +28,16 @@ func TestNewMetaTypeDetectorValid(t *testing.T) {
 			IsDir:       false,
 			Expected: MetaTypeTextScriptImporter,
 		},
+		{
+			MissingMeta: typedpath.NewRawPath("Assets", "README.md.meta"),
+			IsDir:       false,
+			Expected: MetaTypeTextScriptImporter,
+		},
+		{
+			MissingMeta: typedpath.NewRawPath("Assets", "LICENSE.meta"),
+			IsDir:       false,
+			Expected: MetaTypeTextScriptImporter,
+		},
 	}
 
 	for _, c := range cases {

--- a/util/typedpath/raw.go
+++ b/util/typedpath/raw.go
@@ -65,6 +65,10 @@ func (r RawPath) Ext() string {
 	return filepath.Ext(string(r))
 }
 
+func (r RawPath) Base() string {
+	return filepath.Base(string(r))
+}
+
 func (r RawPath) TrimLastSep() RawPath {
 	return RawPath(strings.TrimRight(string(r), string(filepath.Separator)))
 }


### PR DESCRIPTION
Support `*.md` and `LICENSE` that frequently present in UPM packages.