### PR TITLE
Creating major version branch name with pre-release

### DIFF
--- a/.github/workflows/update_major_tag.yml
+++ b/.github/workflows/update_major_tag.yml
@@ -16,6 +16,6 @@ jobs:
           prefix: v
       - name: Update major version and latest tag
         run: |
-          git push --force origin 'HEAD:${{ steps.version.outputs.major_prerelease }}'
-          git push --force origin 'HEAD:latest' 
+          git push --force origin 'HEAD:refs/heads/${{ steps.version.outputs.major_prerelease }}'
+          git push --force origin 'HEAD:refs/heads/latest'
         if: steps.version.outputs.is_valid == 'true'

--- a/.github/workflows/update_major_tag.yml
+++ b/.github/workflows/update_major_tag.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: nowsprinting/check-version-format-action@v1
+      - uses: nowsprinting/check-version-format-action@v3
         id: version
         with:
           prefix: v
       - name: Update major version and latest tag
         run: |
-          git push --force origin 'HEAD:${{ steps.version.outputs.major }}' 
+          git push --force origin 'HEAD:${{ steps.version.outputs.major_prerelease }}'
           git push --force origin 'HEAD:latest' 
         if: steps.version.outputs.is_valid == 'true'

--- a/.idea/mob.xml
+++ b/.idea/mob.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MobProjectSettings">
+    <option name="remoteName" value="origin" />
+    <option name="baseBranch" value="master" />
+    <option name="wipBranch" value="mob-session" />
+    <option name="timerMinutes" value="10" />
+    <option name="wipCommitMessage" value="mob next [ci-skip]" />
+    <option name="nextStay" value="true" />
+  </component>
+</project>


### PR DESCRIPTION
<!-- write content here -->
* Upgrade check-version-format-action v3
* Using output `major_prerelease` for branch name
* Fix create major and latest branch. see https://r7kamura.com/articles/2022-04-16-keep-main-version-branch

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
