### PR TITLE
Fixed missing command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This way is useful to ensure to use the same unity-meta-check version on CI or m
 
 ```console
 $ cd /path/to/your/repo
-$ git add submodule git@github.com:dena/unity-meta-check-bins ./path/to/unity-meta-check-bins
+$ git submodule add git@github.com:dena/unity-meta-check-bins ./path/to/unity-meta-check-bins
 
 $ ./path/to/unity-meta-check-bins/unity-meta-check-easy -help
 ```


### PR DESCRIPTION
<!-- write content here -->

I fixed `git submodule` command's writing in README

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
