### PR TITLE
Fix dubious ownership problem

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dena/unity-meta-check/unity-meta-check-gh-action:3.1.3"
+  image: "docker://ghcr.io/dena/unity-meta-check/unity-meta-check-gh-action:3.1.4-alpha0"
   args:
     - "-inputs-json"
     - "${{ toJSON(inputs) }}"

--- a/git/config.go
+++ b/git/config.go
@@ -1,0 +1,40 @@
+package git
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/DeNA/unity-meta-check/util/logging"
+	"io"
+	"os/exec"
+	"sync"
+)
+
+type GlobalConfig func(stdoutWriter io.WriteCloser, args ...string) error
+
+func NewGlobalConfig(logger logging.Logger) GlobalConfig {
+	return func(stdoutWriter io.WriteCloser, args ...string) error {
+		configWithOpts := append([]string{"config", "--global"}, args...)
+		cmd := exec.Command("git", configWithOpts...)
+		cmd.Stdout = stdoutWriter
+		defer func() { _ = stdoutWriter.Close() }()
+
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			scanner := bufio.NewScanner(stderr)
+			for scanner.Scan() {
+				logger.Debug(fmt.Sprintf("stderr: %s", scanner.Text()))
+			}
+		}()
+
+		err = cmd.Run()
+		wg.Wait()
+		return err
+	}
+}

--- a/git/config_test.go
+++ b/git/config_test.go
@@ -1,0 +1,25 @@
+package git
+
+import (
+	"github.com/DeNA/unity-meta-check/util/logging"
+	"github.com/DeNA/unity-meta-check/util/testutil"
+	"testing"
+)
+
+func TestGlobalConfig(t *testing.T) {
+	spy := testutil.SpyWriteCloser(nil)
+	spyLogger := logging.SpyLogger()
+
+	globalConfig := NewGlobalConfig(spyLogger)
+
+	if err := globalConfig(spy, "--default", "", "--get", "safe.directory"); err != nil {
+		t.Errorf("want nil, got %#v", err)
+		t.Log(spyLogger.Logs.String())
+		return
+	}
+
+	if !spy.IsClosed {
+		t.Error("want true, but false")
+		return
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // NOTE: Also edit the image tag in action.yml
-const Version = "3.1.3"
+const Version = "3.1.4-alpha0"


### PR DESCRIPTION
unity-meta-check via GitHub Actions unexpectedly exit with status 128.

```console
...
info: skip package "com.unity.modules.vehicles" because it does not exist: Packages/com.unity.modules.vehicles
error: exit status 128
##[debug]Docker Action run completed with exit code 1
##[debug]Finishing: Run DeNA/unity-meta-check@v3
```

then, set log_level to "DEBUG":

```console
...
debug: searching: "/github/workspace"
debug: exec: git -c core.quotepath=false ls-files (on "/github/workspace")
debug: stderr: fatal: detected dubious ownership in repository at '/github/workspace'
debug: stderr: To add an exception for this directory, call:
debug: stderr: 
debug: stderr:  git config --global --add safe.directory /github/workspace
error: exit status 128
```

Related: https://github.com/actions/checkout/issues/760

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
