### PR TITLE
Use newer actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
           - windows-latest
           - macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.16
+          go-version: 1.19
       - run: go test -v ./...

--- a/.github/workflows/update_major_tag.yml
+++ b/.github/workflows/update_major_tag.yml
@@ -9,7 +9,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: nowsprinting/check-version-format-action@v3
         id: version
         with:


### PR DESCRIPTION
`checkout@v2` and `setup-go@v1` is deprecated.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
