### PR TITLE
Fix build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # image-name: ghcr.io/dena/unity-meta-check/unity-meta-check
-FROM golang:1.16-buster as builder
+FROM golang:1.19-buster as builder
 WORKDIR /go/src/unity-meta-check
 COPY . .
 RUN make out/unity-meta-check-linux-amd64 out/unity-meta-check-junit-linux-amd64 out/unity-meta-check-github-pr-comment-linux-amd64 out/unity-meta-autofix-linux-amd64 && \


### PR DESCRIPTION
```console
[+] Building 5.5s (12/14)
 => [internal] load build definition from Dockerfile                                                                                                                                      0.0s
 => => transferring dockerfile: 937B                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                         0.0s
 => => transferring context: 34B                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/debian:buster-slim                                                                                                                     2.9s
 => [internal] load metadata for docker.io/library/golang:1.16-buster                                                                                                                     2.6s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                             0.0s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                                             0.0s
 => [builder 1/4] FROM docker.io/library/golang:1.16-buster@sha256:19bc888c9bc1cd6279263449bb3b8c780190aa14706c93ac44d44c3e01f199c2                                                       0.0s
 => [internal] load build context                                                                                                                                                         0.1s
 => => transferring context: 81.59kB                                                                                                                                                      0.1s
 => [stage-1 1/3] FROM docker.io/library/debian:buster-slim@sha256:4d208d79338beaa197912496d0791921a31d9c58fa6fbd299787fab37cc893dd                                                       0.0s
 => CACHED [builder 2/4] WORKDIR /go/src/unity-meta-check                                                                                                                                 0.0s
 => [builder 3/4] COPY . .                                                                                                                                                                0.3s
 => ERROR [builder 4/4] RUN make out/unity-meta-check-linux-amd64 out/unity-meta-check-junit-linux-amd64 out/unity-meta-check-github-pr-comment-linux-amd64 out/unity-meta-autofix-linux  2.1s
------
 > [builder 4/4] RUN make out/unity-meta-check-linux-amd64 out/unity-meta-check-junit-linux-amd64 out/unity-meta-check-github-pr-comment-linux-amd64 out/unity-meta-autofix-linux-amd64 &&    mv ./out/unity-meta-check-linux-amd64 ./out/unity-meta-check &&  mv ./out/unity-meta-check-junit-linux-amd64 ./out/unity-meta-check-junit &&     mv ./out/unity-meta-check-github-pr-comment-linux-amd64 ./out/unity-meta-check-github-pr-comment &&    mv ./out/unity-meta-autofix-linux-amd64 ./out/unity-meta-autofix:
#12 0.577 mkdir -p ./out
#12 0.588 CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -v -o "out/unity-meta-check-linux-amd64"
#12 1.165 go: downloading github.com/pkg/errors v0.9.1
#12 1.187 go: downloading github.com/scylladb/go-set v1.0.2
#12 1.797 github.com/DeNA/unity-meta-check/version
#12 1.875 github.com/DeNA/unity-meta-check/util/testutil
#12 1.877 github.com/DeNA/unity-meta-check/util/typedpath
#12 1.878 github.com/DeNA/unity-meta-check/util/logging
#12 1.879 github.com/DeNA/unity-meta-check/util/errutil
#12 1.879 github.com/scylladb/go-set/strset
#12 1.879 github.com/pkg/errors
#12 1.928 github.com/DeNA/unity-meta-check/util/cli
#12 1.940 github.com/DeNA/unity-meta-check/filecollector/repofinder
#12 1.940 github.com/DeNA/unity-meta-check/util/cstrset
#12 1.940 github.com/DeNA/unity-meta-check/util/ostestable
#12 1.964 github.com/DeNA/unity-meta-check/git
#12 1.980 github.com/DeNA/unity-meta-check/util/pathutil
#12 1.990 # github.com/DeNA/unity-meta-check/util/pathutil
#12 1.990 util/pathutil/tree.go:5:17: syntax error: unexpected interface, expecting ]
#12 1.990 util/pathutil/tree.go:6:22: syntax error: unexpected interface, expecting ]
#12 1.990 util/pathutil/tree.go:10:17: syntax error: unexpected interface, expecting ]
#12 1.990 util/pathutil/tree.go:15:56: syntax error: unexpected [ after top level declaration
#12 1.990 util/pathutil/tree.go:26:27: syntax error: unexpected [, expecting (
#12 1.990 util/pathutil/tree.go:37:30: syntax error: unexpected [ after top level declaration
#12 1.990 util/pathutil/tree.go:55:17: syntax error: unexpected [, expecting comma or )
#12 1.990 util/pathutil/tree.go:66:17: syntax error: unexpected [, expecting comma or )
#12 1.990 util/pathutil/tree.go:75:22: syntax error: unexpected [, expecting comma or )
#12 1.990 util/pathutil/tree.go:89:22: syntax error: unexpected [, expecting comma or )
#12 1.990 util/pathutil/tree.go:89:22: too many errors
#12 1.990 note: module requires Go 1.18
#12 2.040 make: *** [Makefile:45: out/unity-meta-check-linux-amd64] Error 2
------
executor failed running [/bin/sh -c make out/unity-meta-check-linux-amd64 out/unity-meta-check-junit-linux-amd64 out/unity-meta-check-github-pr-comment-linux-amd64 out/unity-meta-autofix-linux-amd64 &&      mv ./out/unity-meta-check-linux-amd64 ./out/unity-meta-check &&         mv ./out/unity-meta-check-junit-linux-amd64 ./out/unity-meta-check-junit &&     mv ./out/unity-meta-check-github-pr-comment-linux-amd64 ./out/unity-meta-check-github-pr-comment &&    mv ./out/unity-meta-autofix-linux-amd64 ./out/unity-meta-autofix]: exit code: 2
```

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
