### PR TITLE
Fix a binary name for gh-action in usage

### DIFF
--- a/tool/gh-action/options/options.go
+++ b/tool/gh-action/options/options.go
@@ -19,10 +19,10 @@ type Parser func(args []string, procInout cli.ProcessInout, env cli.Env) (*Optio
 
 func NewParser() Parser {
 	return func(args []string, procInout cli.ProcessInout, env cli.Env) (*Options, error) {
-		flags := flag.NewFlagSet("unity-meta-check-gh-action", flag.ContinueOnError)
+		flags := flag.NewFlagSet("gh-action", flag.ContinueOnError)
 		flags.SetOutput(procInout.Stderr)
 		flags.Usage = func() {
-			_, _ = fmt.Fprintln(flags.Output(), "usage: unity-meta-check-gh-action -inputs-json <json>")
+			_, _ = fmt.Fprintln(flags.Output(), "usage: gh-action -inputs-json <json>")
 			flags.PrintDefaults()
 		}
 


### PR DESCRIPTION
### Before

```console
$ gh-action --help
usage: unity-meta-check-gh-action -inputs-json <json>
  -inputs-json string
        JSON string of "inputs" context value of GitHub Actions
  -version
        print version
```

### After

```console
$ gh-action --help
usage: gh-action -inputs-json <json>
  -inputs-json string
        JSON string of "inputs" context value of GitHub Actions
  -version
        print version
```

### Acknowledgment
ReportedBy: @ponkio-o

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
