### PR TITLE
fix: added permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -49,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
 
     strategy:
       matrix:


### PR DESCRIPTION
<!-- write content here -->
I forgot to add the necessary permissions for docker push.

And may be you need to change the configuration of packages. 
ref. https://blog.yukirii.dev/github-action-ghcr-push-error/


follow up: https://github.com/DeNA/unity-meta-check/pull/39

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
