### PR TITLE
fix: use github.repository_owner instead of github.actor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
@@ -82,7 +82,7 @@ jobs:
         uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push


### PR DESCRIPTION
<!-- write content here -->
Change to use `github.repository_owner` instead of `github.actor`.
![CleanShot 2024-05-13 at 16 27 46](https://github.com/DeNA/unity-meta-check/assets/29038315/3303b718-77d7-41dc-8266-0cb88ce245eb)


related: https://github.com/DeNA/unity-meta-check/pull/39
---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
